### PR TITLE
Don't create a patch file when arguments are invalid

### DIFF
--- a/git-fix-whitespace
+++ b/git-fix-whitespace
@@ -1,17 +1,27 @@
 #!/bin/bash
-usage(){
-cat << EOF
-git-fix-whitespace - Fixes the whitespace issues that 'git-diff --check' complains about.
+usage() {
+    me="$(basename $0)"
+    cat << EOF
+git-fix-whitespace - Fixes the whitespace issues that 'git-diff --check'
+                     complains about.
 Usage:
-    $0 --cached
-    $0 tree-ish tree-ish
+    $me --cached
+    $me tree-ish tree-ish
+
 Synopsis:
-    In its first form the index is modified to correct the whitespace issues found in the files added to the index.
-    In its second form the index is modified to correct the whitespace issues found in the files that changed between the 2 hashes given.
+    In its first form the index is modified to correct the whitespace issues
+    found in the files added to the index.
+
+    In its second form the index is modified to correct the whitespace issues
+    found in the files that changed between the 2 hashes given.
 
 Notes:
- 1. In git terminology "tree-sh" refers to anything that can be resolved to a tree, including a hash, tag, branch, or something like HEAD~3 (meaning 3 commits prior to HEAD).
- 2. This script does not use perl/awk/sed/etc. to do is modifications. It uses git's own functionality. For this reason it should be very future-proof.
+  1. In git terminology "tree-sh" refers to anything that can be resolved to a
+     tree, including a hash, tag, branch, or something like HEAD~3 (meaning 3
+     commits prior to HEAD).
+
+  2. This script does not use perl/awk/sed/etc. to do is modifications. It uses
+     git's own functionality. For this reason it should be very future-proof.
 
 Acknowledgments:
     Copyright (c) 2010 Richard Bronosky
@@ -19,11 +29,14 @@ Acknowledgments:
     http://www.opensource.org/licenses/mit-license.php
     Created while employed by CMGdigital
 EOF
+exit
 }
 
 apply_fail(){
     echo "Failed to apply patch $PATCH"
-    echo "Perhaps you tried to do a hash comparison with uncommitted changes in your working tree."
+    echo
+    echo "Perhaps you tried to do a hash comparison with uncommitted changes in your"
+    echo "working tree."
     exit $1
 }
 

--- a/git-fix-whitespace
+++ b/git-fix-whitespace
@@ -1,9 +1,12 @@
 #!/bin/bash
+
+me="$(basename $0)"
+
 usage() {
-    me="$(basename $0)"
     cat << EOF
 git-fix-whitespace - Fixes the whitespace issues that 'git-diff --check'
                      complains about.
+
 Usage:
     $me --cached
     $me tree-ish tree-ish
@@ -44,17 +47,34 @@ err_files(){
     git diff $ARG1 $ARG2 --check | sed -E '/^(\+|-)/d;s/:.*//' | sort | uniq
 }
 
-PATCH=$(mktemp ${0##*/}.patch.XXXXXX)
-if [[ $# == 1 && "$1" == "--cached" ]]; then
-    ARG1=$1
-    ARG2=HEAD
-elif [[ $# == 2 ]]; then
-    ARG1=$1
-    ARG2=$2
-else
-    usage
-    exit
-fi
+case "$#" in
+    1)
+        test "$1" = "--cached" && ARG1=$1 || {
+            echo
+            echo "Inavlid arguments"
+            echo
+            echo
+            usage
+        }
+        ARG1=$1
+        ARG2=HEAD
+        ;;
+    2)
+        ARG1=$1
+        ARG2=$2
+        ;;
+    *)
+        test $# > 3 && {
+            echo
+            echo "Invalid arguments"
+            echo
+            echo
+        }
+        usage
+        ;;
+esac
+
+PATCH=$(mktemp -p $(pwd -P) ${me}.patch.XXXXXX)
 git diff $ARG1 $ARG2 > $PATCH
 FILES=$(sed '/^+++ /!d;s?^+++ b/??' $PATCH)
 echo -e "Files in index with whitespace errors:\n$(err_files 1)"


### PR DESCRIPTION
This pull request is for a patch that

1. Improves readability of the usage text
2. Improves argument processing and validation
3. Fixes temp file creation so temp files are created in the invoking directory instead of the executing directory
4. Doesn't create unnecessary temporary files when script arguments are invalid (which then, previously, these files were not cleaned up leaving the user's system littered with useless temp files).
