### PR TITLE
Fix mktemp for macos

### DIFF
--- a/git-fix-whitespace
+++ b/git-fix-whitespace
@@ -74,7 +74,7 @@ case "$#" in
         ;;
 esac
 
-PATCH=$(mktemp -p $(pwd -P) ${me}.patch.XXXXXX)
+PATCH=$(mktemp $(pwd -P)/${me}.patch.XXXXXX)
 git diff $ARG1 $ARG2 > $PATCH
 FILES=$(sed '/^+++ /!d;s?^+++ b/??' $PATCH)
 echo -e "Files in index with whitespace errors:\n$(err_files 1)"


### PR DESCRIPTION
MacOS's version of `mktemp` doesn't have the `-p` option. 